### PR TITLE
Add customer workflow simulation with queue management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/customer.py
+++ b/customer.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Customer:
+    """Represents a customer waiting for service."""
+
+    request_type: str
+    patience: int
+    satisfaction: int = 0
+
+    def decrement_patience(self, amount: int = 1) -> int:
+        """Decrease patience by ``amount`` and return remaining patience."""
+        self.patience = max(0, self.patience - amount)
+        return self.patience
+
+    @property
+    def walked_out(self) -> bool:
+        """Whether the customer has left the queue due to zero patience."""
+        return self.patience == 0

--- a/queue_manager.py
+++ b/queue_manager.py
@@ -1,0 +1,34 @@
+from collections import deque
+from typing import Deque, List, Optional
+
+from customer import Customer
+
+
+class QueueManager:
+    """Manages a line of customers waiting for service."""
+
+    def __init__(self) -> None:
+        self._queue: Deque[Customer] = deque()
+
+    def add_customer(self, customer: Customer) -> None:
+        """Add a new customer to the queue."""
+        self._queue.append(customer)
+
+    def tick(self, amount: int = 1) -> List[Customer]:
+        """Advance time by reducing patience; return customers who walked out."""
+        walked_out: List[Customer] = []
+        for cust in list(self._queue):
+            cust.decrement_patience(amount)
+            if cust.walked_out:
+                self._queue.remove(cust)
+                walked_out.append(cust)
+        return walked_out
+
+    def pop_next(self) -> Optional[Customer]:
+        """Retrieve the next customer in line."""
+        if self._queue:
+            return self._queue.popleft()
+        return None
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._queue)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -1,0 +1,10 @@
+from customer import Customer
+
+
+def test_customer_patience_decrements_and_walkout():
+    customer = Customer("copy", patience=2)
+    customer.decrement_patience()
+    assert customer.patience == 1
+    assert not customer.walked_out
+    customer.decrement_patience()
+    assert customer.walked_out

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,11 @@
+from customer import Customer
+from queue_manager import QueueManager
+
+
+def test_queue_manager_walk_out():
+    manager = QueueManager()
+    cust = Customer("print", patience=1)
+    manager.add_customer(cust)
+    walked_out = manager.tick()
+    assert walked_out == [cust]
+    assert len(manager) == 0

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,9 @@
+from customer import Customer
+from workflow import Station, run_workflow
+
+
+def test_run_workflow_increases_satisfaction():
+    customer = Customer("scan", patience=3)
+    station = Station()
+    run_workflow(customer, station)
+    assert customer.satisfaction == 4

--- a/workflow.py
+++ b/workflow.py
@@ -1,0 +1,33 @@
+from customer import Customer
+
+
+class Station:
+    """Represents a workstation that can process a job."""
+
+    def process(self, request_type: str) -> str:
+        return f"Processed {request_type}"
+
+
+def greet(customer: Customer) -> None:
+    customer.satisfaction += 1
+
+
+def process_job(customer: Customer, station: Station) -> None:
+    station.process(customer.request_type)
+    customer.satisfaction += 1
+
+
+def deliver(customer: Customer) -> None:
+    customer.satisfaction += 1
+
+
+def checkout(customer: Customer) -> None:
+    customer.satisfaction += 1
+
+
+def run_workflow(customer: Customer, station: Station) -> None:
+    """Run the full workflow for a single customer."""
+    greet(customer)
+    process_job(customer, station)
+    deliver(customer)
+    checkout(customer)


### PR DESCRIPTION
## Summary
- Implement `Customer` dataclass with patience and satisfaction tracking
- Add `QueueManager` to tick patience and handle walk-outs
- Provide workflow steps (greet ➜ process ➜ deliver ➜ checkout) and accompanying tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0d77be4f483248ef29e3cae3e48d0