### PR TITLE
Add machine modules with interactive hooks

### DIFF
--- a/machines/__init__.py
+++ b/machines/__init__.py
@@ -1,0 +1,18 @@
+"""Machine modules for the print shop simulation."""
+
+from .base import Machine, MachineError
+from .printer import Printer
+from .binder import Binder
+from .cutter import Cutter
+from .laminator import Laminator
+from .folder import Folder
+
+__all__ = [
+    "Machine",
+    "MachineError",
+    "Printer",
+    "Binder",
+    "Cutter",
+    "Laminator",
+    "Folder",
+]

--- a/machines/base.py
+++ b/machines/base.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+class MachineError(Exception):
+    """Raised when a machine encounters an error."""
+
+
+@dataclass
+class Machine:
+    """Base class for print shop machines.
+
+    Provides hooks for starting a job, tracking progress and completing a job.
+    Concrete machines should trigger cues on completion or error.
+    """
+
+    name: str
+    progress_value: int = 0
+    job: Optional[str] = None
+    cues: List[str] = field(default_factory=list)
+
+    def start_job(self, job: str) -> None:
+        """Begin processing a new job."""
+        self.job = job
+        self.progress_value = 0
+        self.cues.clear()
+        self.trigger_cue("visual: start")
+        self.trigger_cue("audio: start")
+
+    def progress(self, amount: int) -> None:
+        """Advance the job by ``amount`` percent."""
+        if self.job is None:
+            raise MachineError("No active job")
+        self.progress_value = min(100, self.progress_value + amount)
+
+    def complete(self) -> str:
+        """Mark the current job as complete and emit cues."""
+        if self.job is None:
+            raise MachineError("No active job")
+        self.trigger_cue("visual: complete")
+        self.trigger_cue("audio: complete")
+        job = self.job
+        self.job = None
+        return job
+
+    def error(self, reason: str) -> None:
+        """Abort the current job and emit error cues."""
+        self.trigger_cue(f"visual: error {reason}")
+        self.trigger_cue(f"audio: error {reason}")
+        self.job = None
+        raise MachineError(reason)
+
+    def trigger_cue(self, cue: str) -> None:
+        """Record a visual or audio cue."""
+        self.cues.append(cue)

--- a/machines/binder.py
+++ b/machines/binder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .base import Machine, MachineError
+
+
+class Binder(Machine):
+    """Binding machine where players input the correct spine measurement."""
+
+    def __init__(self, target_width: float = 1.0, tolerance: float = 0.05) -> None:
+        super().__init__(name="Binder")
+        self.target_width = target_width
+        self.tolerance = tolerance
+        self._success: bool | None = None
+
+    def start_job(self, job: str) -> None:  # type: ignore[override]
+        super().start_job(job)
+        self._success = None
+
+    def progress(self, measurement: float) -> None:  # type: ignore[override]
+        """Player inputs the measured spine width for binding."""
+        if self.job is None:
+            raise MachineError("No active job")
+        self._success = abs(measurement - self.target_width) <= self.tolerance
+        self.progress_value = 100
+
+    def complete(self) -> str:  # type: ignore[override]
+        if self.job is None:
+            raise MachineError("No active job")
+        if not self._success:
+            self.error("binding failed")
+        return super().complete()

--- a/machines/cutter.py
+++ b/machines/cutter.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from .base import Machine, MachineError
+
+
+class Cutter(Machine):
+    """Large-scale cutter that stacks jobs of the same cut type.
+
+    Each job specifies a ``cut_type`` and number of ``cuts``. Jobs with the
+    same ``cut_type`` can be stacked together, sharing a single setup time and
+    completing faster than running individually.
+    """
+
+    def __init__(self, time_per_cut: float = 1.0, setup_time: float = 2.0) -> None:
+        super().__init__(name="Cutter")
+        self.time_per_cut = time_per_cut
+        self.setup_time = setup_time
+        self.current_cut_type: str | None = None
+        self.jobs: list[str] = []
+        self.total_cuts = 0
+        self.time_spent = 0.0
+        self.time_required = 0.0
+
+    def start_job(self, job: str, cut_type: str, cuts: int) -> None:  # type: ignore[override]
+        if self.job is None:
+            self.current_cut_type = cut_type
+            self.jobs = [job]
+            self.total_cuts = cuts
+            self.time_spent = 0.0
+            self.time_required = self.setup_time + self.total_cuts * self.time_per_cut
+            super().start_job(job)
+        elif cut_type == self.current_cut_type:
+            # Stack job with current batch
+            self.jobs.append(job)
+            self.total_cuts += cuts
+            self.time_required = self.setup_time + self.total_cuts * self.time_per_cut
+            self.job += f"+{job}"
+        else:
+            raise MachineError("different cut type in progress")
+
+    def progress(self, time: float) -> None:  # type: ignore[override]
+        if self.job is None:
+            raise MachineError("No active job")
+        self.time_spent += time
+        ratio = self.time_spent / self.time_required if self.time_required else 0.0
+        self.progress_value = min(100, int(ratio * 100))
+
+    def complete(self) -> str:  # type: ignore[override]
+        if self.job is None:
+            raise MachineError("No active job")
+        if self.progress_value < 100:
+            self.error("cuts not finished")
+        result = super().complete()
+        # Reset for next batch
+        self.current_cut_type = None
+        self.jobs = []
+        self.total_cuts = 0
+        self.time_spent = 0.0
+        self.time_required = 0.0
+        return result
+

--- a/machines/folder.py
+++ b/machines/folder.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .base import Machine, MachineError
+
+
+class Folder(Machine):
+    """Folding machine that may jam at a specified progress level."""
+
+    def __init__(self, jam_at: int | None = None) -> None:
+        super().__init__(name="Folder")
+        self.jam_at = jam_at
+
+    def progress(self, amount: int) -> None:  # type: ignore[override]
+        super().progress(amount)
+        if self.jam_at is not None and self.progress_value >= self.jam_at:
+            self.error("fold jam")
+

--- a/machines/laminator.py
+++ b/machines/laminator.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .base import Machine, MachineError
+
+
+class Laminator(Machine):
+    """Simple laminator that can run out of film."""
+
+    def __init__(self, film_available: bool = True) -> None:
+        super().__init__(name="Laminator")
+        self.film_available = film_available
+
+    def start_job(self, job: str) -> None:  # type: ignore[override]
+        if not self.film_available:
+            self.error("out of film")
+        super().start_job(job)
+

--- a/machines/printer.py
+++ b/machines/printer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .base import Machine, MachineError
+
+
+class Printer(Machine):
+    """Simulates a printer with potential jams or paper shortages."""
+
+    def __init__(self, paper_available: bool = True, jam_at: int | None = None) -> None:
+        super().__init__(name="Printer")
+        self.paper_available = paper_available
+        self.jam_at = jam_at
+
+    def start_job(self, job: str) -> None:  # type: ignore[override]
+        if not self.paper_available:
+            self.error("out of paper")
+        super().start_job(job)
+
+    def progress(self, amount: int) -> None:  # type: ignore[override]
+        super().progress(amount)
+        if self.jam_at is not None and self.progress_value >= self.jam_at:
+            self.error("paper jam")

--- a/tests/test_machines.py
+++ b/tests/test_machines.py
@@ -1,0 +1,53 @@
+import pytest
+
+from machines import Binder, MachineError, Printer, Cutter, Laminator, Folder
+
+
+def test_binder_measurement_success():
+    binder = Binder(target_width=1.0, tolerance=0.1)
+    binder.start_job("bind report")
+    binder.progress(1.05)  # within tolerance
+    binder.complete()
+    assert any("visual: complete" in cue for cue in binder.cues)
+
+
+def test_binder_measurement_failure_triggers_cues():
+    binder = Binder(target_width=1.0, tolerance=0.1)
+    binder.start_job("bind report")
+    binder.progress(0.5)  # wrong measurement
+    with pytest.raises(MachineError):
+        binder.complete()
+    assert any("error binding failed" in cue for cue in binder.cues)
+
+
+def test_printer_jam_triggers_cues():
+    printer = Printer(jam_at=50)
+    printer.start_job("print flyer")
+    with pytest.raises(MachineError):
+        printer.progress(60)
+    assert any("error paper jam" in cue for cue in printer.cues)
+
+
+def test_cutter_stacks_same_cut_type():
+    cutter = Cutter(time_per_cut=1.0, setup_time=2.0)
+    cutter.start_job("cut cards", cut_type="trim", cuts=2)
+    cutter.start_job("cut flyers", cut_type="trim", cuts=2)
+    assert cutter.time_required == 6  # setup once + 4 cuts
+    cutter.progress(6)
+    cutter.complete()
+    assert cutter.progress_value == 100
+
+
+def test_laminator_out_of_film_triggers_cues():
+    laminator = Laminator(film_available=False)
+    with pytest.raises(MachineError):
+        laminator.start_job("laminate poster")
+    assert any("error out of film" in cue for cue in laminator.cues)
+
+
+def test_folder_jam_triggers_cues():
+    folder = Folder(jam_at=50)
+    folder.start_job("fold brochure")
+    with pytest.raises(MachineError):
+        folder.progress(60)
+    assert any("error fold jam" in cue for cue in folder.cues)


### PR DESCRIPTION
## Summary
- introduce a `machines` package with base `Machine` class and error handling
- add `Printer`, `Binder`, and `Cutter` machines exposing `start_job`, `progress`, and `complete` hooks
- include a timing mini-game for the binding machine and cue triggers for completions and errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0d8c8a3e48324a8c2754b485598c5