### PR TITLE
Add HUD and navigation utilities with keyboard support

### DIFF
--- a/hud.py
+++ b/hud.py
@@ -1,0 +1,45 @@
+"""Heads-up display components for the print shop simulation."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from machines.base import Machine
+from queue_manager import QueueManager
+
+
+class QueueDisplay:
+    """Simple text-based queue display."""
+
+    def render(self, queue: QueueManager) -> List[str]:
+        """Return a list of customer request types in order."""
+        return [cust.request_type for cust in queue.list_customers()]
+
+
+class MachineStatusPanel:
+    """Display status information for a machine."""
+
+    def render(self, machine: Machine) -> str:
+        job = machine.job or "idle"
+        return f"{machine.name}: {job} ({machine.progress_value}%)"
+
+
+class JobHUD:
+    """Track and display the workflow steps for a job."""
+
+    steps: Iterable[str] = ("greet", "process_job", "deliver", "checkout")
+
+    def __init__(self) -> None:
+        self.completed: List[str] = []
+
+    def mark_complete(self, step: str) -> None:
+        """Mark a workflow step as completed."""
+        if step in self.steps and step not in self.completed:
+            self.completed.append(step)
+
+    def render(self) -> List[str]:
+        """Return a checklist style representation of the workflow."""
+        return [
+            ("[x] " + step) if step in self.completed else ("[ ] " + step)
+            for step in self.steps
+        ]

--- a/navigation.py
+++ b/navigation.py
@@ -1,0 +1,54 @@
+"""Navigation utilities with keyboard hotkeys and pathfinding."""
+
+from __future__ import annotations
+
+from collections import deque
+from enum import Enum
+from typing import Callable, Dict, Iterable, List
+
+
+class HotkeyManager:
+    """Register and trigger actions via keyboard hotkeys."""
+
+    def __init__(self) -> None:
+        self._actions: Dict[str, Callable[..., object]] = {}
+
+    def register(self, key: str, action: Callable[..., object]) -> None:
+        self._actions[key] = action
+
+    def trigger(self, key: str, *args, **kwargs) -> object:
+        if key not in self._actions:
+            raise KeyError(f"No action bound for {key}")
+        return self._actions[key](*args, **kwargs)
+
+
+class NavigationMode(Enum):
+    PATHFINDING = "pathfinding"
+    INSTANT = "instant"
+
+
+class Navigator:
+    """Select stations using either pathfinding or instant travel."""
+
+    def __init__(self, graph: Dict[str, Iterable[str]], mode: NavigationMode = NavigationMode.PATHFINDING) -> None:
+        self.graph = graph
+        self.mode = mode
+
+    def select_station(self, start: str, target: str) -> List[str]:
+        """Return path to ``target`` based on navigation mode."""
+        if self.mode is NavigationMode.INSTANT:
+            return [target]
+        return self._bfs_path(start, target)
+
+    def _bfs_path(self, start: str, target: str) -> List[str]:
+        queue = deque([(start, [start])])
+        visited = {start}
+        while queue:
+            node, path = queue.popleft()
+            if node == target:
+                return path
+            for neighbour in self.graph.get(node, []):
+                if neighbour not in visited:
+                    visited.add(neighbour)
+                    queue.append((neighbour, path + [neighbour]))
+        return []

--- a/queue_manager.py
+++ b/queue_manager.py
@@ -14,6 +14,10 @@ class QueueManager:
         """Add a new customer to the queue."""
         self._queue.append(customer)
 
+    def list_customers(self) -> List[Customer]:
+        """Return a snapshot list of customers currently in queue."""
+        return list(self._queue)
+
     def tick(self, amount: int = 1) -> List[Customer]:
         """Advance time by reducing patience; return customers who walked out."""
         walked_out: List[Customer] = []

--- a/tests/test_ui_navigation.py
+++ b/tests/test_ui_navigation.py
@@ -1,0 +1,51 @@
+import pytest
+
+from customer import Customer
+from machines.base import Machine
+from queue_manager import QueueManager
+from hud import JobHUD, MachineStatusPanel, QueueDisplay
+from navigation import HotkeyManager, NavigationMode, Navigator
+
+
+def test_queue_display_lists_customers():
+    qm = QueueManager()
+    qm.add_customer(Customer("copy", patience=5))
+    qm.add_customer(Customer("print", patience=5))
+    display = QueueDisplay()
+    assert display.render(qm) == ["copy", "print"]
+
+
+def test_machine_status_panel_shows_job_and_progress():
+    machine = Machine(name="Printer")
+    machine.start_job("flyers")
+    machine.progress(30)
+    panel = MachineStatusPanel()
+    assert panel.render(machine) == "Printer: flyers (30%)"
+
+
+def test_job_hud_tracks_completed_steps():
+    hud = JobHUD()
+    hud.mark_complete("greet")
+    hud.mark_complete("deliver")
+    assert hud.render() == ["[x] greet", "[ ] process_job", "[x] deliver", "[ ] checkout"]
+
+
+def test_hotkey_manager_triggers_actions():
+    manager = HotkeyManager()
+    flag = {"called": False}
+
+    def action():
+        flag["called"] = True
+
+    manager.register("g", action)
+    manager.trigger("g")
+    assert flag["called"]
+
+
+def test_navigator_pathfinding_and_instant_modes():
+    graph = {"counter": ["printer"], "printer": ["cutter"], "cutter": []}
+    nav = Navigator(graph, NavigationMode.PATHFINDING)
+    assert nav.select_station("counter", "cutter") == ["counter", "printer", "cutter"]
+
+    nav_fast = Navigator(graph, NavigationMode.INSTANT)
+    assert nav_fast.select_station("counter", "cutter") == ["cutter"]


### PR DESCRIPTION
## Summary
- Implement text-based queue display, machine status panels and job HUD
- Add hotkey manager and navigator with pathfinding or instant station selection modes
- Extend QueueManager with method to list customers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0db46392883249645d972f5b4c214