### PR TITLE
Add tutorial guidance and machine locking

### DIFF
--- a/machines/base.py
+++ b/machines/base.py
@@ -20,9 +20,20 @@ class Machine:
     progress_value: int = 0
     job: Optional[str] = None
     cues: List[str] = field(default_factory=list)
+    locked: bool = False
+
+    def lock(self) -> None:
+        """Prevent the machine from being used."""
+        self.locked = True
+
+    def unlock(self) -> None:
+        """Allow the machine to be used."""
+        self.locked = False
 
     def start_job(self, job: str) -> None:
         """Begin processing a new job."""
+        if self.locked:
+            raise MachineError("Machine locked")
         self.job = job
         self.progress_value = 0
         self.cues.clear()

--- a/machines/binder.py
+++ b/machines/binder.py
@@ -7,7 +7,7 @@ class Binder(Machine):
     """Binding machine where players input the correct spine measurement."""
 
     def __init__(self, target_width: float = 1.0, tolerance: float = 0.05) -> None:
-        super().__init__(name="Binder")
+        super().__init__(name="Binder", locked=True)
         self.target_width = target_width
         self.tolerance = tolerance
         self._success: bool | None = None

--- a/machines/cutter.py
+++ b/machines/cutter.py
@@ -12,7 +12,7 @@ class Cutter(Machine):
     """
 
     def __init__(self, time_per_cut: float = 1.0, setup_time: float = 2.0) -> None:
-        super().__init__(name="Cutter")
+        super().__init__(name="Cutter", locked=True)
         self.time_per_cut = time_per_cut
         self.setup_time = setup_time
         self.current_cut_type: str | None = None

--- a/machines/folder.py
+++ b/machines/folder.py
@@ -7,7 +7,7 @@ class Folder(Machine):
     """Folding machine that may jam at a specified progress level."""
 
     def __init__(self, jam_at: int | None = None) -> None:
-        super().__init__(name="Folder")
+        super().__init__(name="Folder", locked=True)
         self.jam_at = jam_at
 
     def progress(self, amount: int) -> None:  # type: ignore[override]

--- a/machines/laminator.py
+++ b/machines/laminator.py
@@ -7,7 +7,7 @@ class Laminator(Machine):
     """Simple laminator that can run out of film."""
 
     def __init__(self, film_available: bool = True) -> None:
-        super().__init__(name="Laminator")
+        super().__init__(name="Laminator", locked=True)
         self.film_available = film_available
 
     def start_job(self, job: str) -> None:  # type: ignore[override]

--- a/pause_menu.py
+++ b/pause_menu.py
@@ -1,0 +1,26 @@
+"""Pause menu with access to the replayable tutorial."""
+from __future__ import annotations
+
+from typing import Optional
+
+from tutorial import Tutorial, TutorialStep
+
+
+class PauseMenu:
+    """Represents a very small pause menu.
+
+    The menu exposes a :meth:`replay_tutorial` method which resets and restarts
+    the provided :class:`Tutorial`.  The method returns the first
+    :class:`TutorialStep` so callers can immediately display the opening
+    instruction again.
+    """
+
+    def __init__(self, tutorial: Tutorial) -> None:
+        self.tutorial = tutorial
+
+    def replay_tutorial(self) -> Optional[TutorialStep]:
+        """Restart the tutorial from the beginning."""
+        self.tutorial.reset()
+        if self.tutorial.steps:
+            return self.tutorial.start()
+        return None

--- a/tests/test_machines.py
+++ b/tests/test_machines.py
@@ -5,6 +5,8 @@ from machines import Binder, MachineError, Printer, Cutter, Laminator, Folder
 
 def test_binder_measurement_success():
     binder = Binder(target_width=1.0, tolerance=0.1)
+    assert binder.locked
+    binder.unlock()
     binder.start_job("bind report")
     binder.progress(1.05)  # within tolerance
     binder.complete()
@@ -13,6 +15,7 @@ def test_binder_measurement_success():
 
 def test_binder_measurement_failure_triggers_cues():
     binder = Binder(target_width=1.0, tolerance=0.1)
+    binder.unlock()
     binder.start_job("bind report")
     binder.progress(0.5)  # wrong measurement
     with pytest.raises(MachineError):
@@ -30,6 +33,8 @@ def test_printer_jam_triggers_cues():
 
 def test_cutter_stacks_same_cut_type():
     cutter = Cutter(time_per_cut=1.0, setup_time=2.0)
+    assert cutter.locked
+    cutter.unlock()
     cutter.start_job("cut cards", cut_type="trim", cuts=2)
     cutter.start_job("cut flyers", cut_type="trim", cuts=2)
     assert cutter.time_required == 6  # setup once + 4 cuts
@@ -40,6 +45,8 @@ def test_cutter_stacks_same_cut_type():
 
 def test_laminator_out_of_film_triggers_cues():
     laminator = Laminator(film_available=False)
+    assert laminator.locked
+    laminator.unlock()
     with pytest.raises(MachineError):
         laminator.start_job("laminate poster")
     assert any("error out of film" in cue for cue in laminator.cues)
@@ -47,7 +54,16 @@ def test_laminator_out_of_film_triggers_cues():
 
 def test_folder_jam_triggers_cues():
     folder = Folder(jam_at=50)
+    assert folder.locked
+    folder.unlock()
     folder.start_job("fold brochure")
     with pytest.raises(MachineError):
         folder.progress(60)
     assert any("error fold jam" in cue for cue in folder.cues)
+
+
+def test_advanced_machines_start_locked():
+    assert Binder().locked
+    assert Cutter().locked
+    assert Laminator().locked
+    assert Folder().locked

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,25 @@
+import pytest
+
+from machines import Binder, Printer
+from tutorial import default_tutorial
+from pause_menu import PauseMenu
+
+
+def test_tutorial_unlocks_machines_and_replays():
+    printer = Printer()
+    binder = Binder()
+    tut = default_tutorial(printer, binder)
+
+    step = tut.start()
+    assert step.station == "Printer"
+    assert binder.locked
+
+    tut.next_step()  # start job
+    step = tut.next_step()  # move to binder step
+    assert step.station == "Binder"
+    assert not binder.locked  # binder unlocked when step becomes active
+
+    menu = PauseMenu(tut)
+    menu.replay_tutorial()
+    assert binder.locked  # tutorial reset relocks binder
+    assert tut.current_step().station == "Printer"

--- a/tutorial.py
+++ b/tutorial.py
@@ -1,0 +1,97 @@
+"""Simple step-by-step tutorial system for the print shop game.
+
+The tutorial guides the player through the first few jobs by presenting
+instructions that include the relevant control input and workstation.  Advanced
+machines remain locked until a step that references them becomes active.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from machines.base import Machine
+
+
+@dataclass
+class TutorialStep:
+    """A single step in the tutorial sequence."""
+
+    instruction: str
+    control: str
+    station: str
+    machine: Optional[Machine] = None
+
+
+class Tutorial:
+    """Manage a sequence of :class:`TutorialStep` objects.
+
+    The tutorial can be started, advanced through steps and reset in order to be
+    replayed.  When a step becomes active any associated machine is unlocked so
+    that it may be used.
+    """
+
+    def __init__(self, steps: List[TutorialStep]) -> None:
+        self.steps = steps
+        self.index = 0
+        self.active = False
+
+    def start(self) -> TutorialStep:
+        """Begin the tutorial and return the first step."""
+        self.active = True
+        self.index = 0
+        return self.current_step()
+
+    def current_step(self) -> TutorialStep:
+        """Return the currently active step and unlock its machine."""
+        step = self.steps[self.index]
+        if step.machine:
+            step.machine.unlock()
+        return step
+
+    def next_step(self) -> Optional[TutorialStep]:
+        """Advance to the next step and return it.
+
+        Returns ``None`` when the tutorial has been completed.
+        """
+        if not self.active:
+            return self.start()
+        self.index += 1
+        if self.index >= len(self.steps):
+            self.active = False
+            return None
+        return self.current_step()
+
+    def reset(self) -> None:
+        """Reset the tutorial so it can be replayed.
+
+        Any machines referenced by steps are locked again so the tutorial can
+        guide the player from the start on subsequent playthroughs.
+        """
+        for step in self.steps:
+            if step.machine:
+                step.machine.lock()
+        self.index = 0
+        self.active = False
+
+    def is_complete(self) -> bool:
+        """Whether all steps have been completed."""
+        return not self.active and self.index >= len(self.steps)
+
+
+def default_tutorial(printer: Machine, binder: Machine) -> Tutorial:
+    """Create a basic tutorial for the first jobs.
+
+    Parameters
+    ----------
+    printer, binder:
+        Machine instances used in the tutorial.  The binder is expected to be
+        locked and will be unlocked when its step becomes active.
+    """
+
+    steps = [
+        TutorialStep("Approach the printer", "WASD", "Printer", printer),
+        TutorialStep("Start the print job", "E", "Printer"),
+        TutorialStep("Carry prints to the binder", "WASD", "Binder", binder),
+        TutorialStep("Bind the booklet", "E", "Binder"),
+    ]
+    return Tutorial(steps)


### PR DESCRIPTION
## Summary
- Provide replayable tutorial system that unlocks machines step by step
- Lock advanced machines until the tutorial introduces them
- Add pause menu option to restart the tutorial

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0dcae9e7083248b86891a23a72a43